### PR TITLE
Add `updateItemQuantitiesById` method.

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -111,6 +111,9 @@
         "update-item-by-id": {
           "title": "updateItemById"
         },
+        "update-item-quantities-by-id": {
+          "title": "updateItemQuantitiesById"
+        },
         "remove-item-by-id": {
           "title": "removeItemById"
         },

--- a/docs/reference/sections/core-api/update-item-quantities-by-id.md
+++ b/docs/reference/sections/core-api/update-item-quantities-by-id.md
@@ -1,0 +1,10 @@
+`CartJS.updateItemQuantitiesById(updates = {})`
+
+Update the quantities of many line items in the cart at once, using a mapping of variant IDs
+to the desired quantity. Line items with variants IDs omitted from the `updates` hash will
+not have their quantities changed.
+
+```js
+// Make sure we have 6x blue socks (variant #12345678) and 0x red socks (variant #12345680).
+CartJS.updateItemQuantitiesById({12345678: 6, 12345680: 0});
+```

--- a/src/core.coffee
+++ b/src/core.coffee
@@ -36,6 +36,10 @@ CartJS.Core =
       data.quantity = quantity
     CartJS.Queue.add '/cart/change.js', data, CartJS.cart.update
 
+  # Set the quantities of a number of items in the cart with an ID/Quantity "updates" mapping.
+  updateItemQuantitiesById: (updates = {}) ->
+    CartJS.Queue.add '/cart/update.js', {updates: updates}, CartJS.cart.update
+
   # Remove all line items for the given variant ID.
   removeItemById: (id) ->
     data =

--- a/src/export.coffee
+++ b/src/export.coffee
@@ -19,6 +19,7 @@ CartJS.factory = (exports) ->
   exports.addItem = CartJS.Core.addItem
   exports.updateItem = CartJS.Core.updateItem
   exports.updateItemById = CartJS.Core.updateItemById
+  exports.updateItemQuantitiesById = CartJS.Core.updateItemQuantitiesById
   exports.removeItem = CartJS.Core.removeItem
   exports.removeAll = CartJS.Core.removeAll
   exports.clear = CartJS.Core.clear


### PR DESCRIPTION
Allows setting of many line items at once by ID.

Add documentation for new method.

Resolves #13.