### PR TITLE
Add weight formatter

### DIFF
--- a/src/cartjs.coffee
+++ b/src/cartjs.coffee
@@ -11,6 +11,7 @@ CartJS =
     currency: null
     moneyFormat: null
     moneyWithCurrencyFormat: null
+    weightUnit: 'kg'
 
 
   # Our extended cart model.

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -92,6 +92,12 @@ if 'rivets' of window
   rivets.formatters.money_with_currency = (value, currency) ->
     CartJS.Utils.formatMoney(value, CartJS.settings.moneyWithCurrencyFormat, 'money_with_currency_format', currency)
 
+  rivets.formatters.weight_with_unit = (value) ->
+    value / 1000 + ' ' + CartJS.settings.weightUnit;
+
+  rivets.formatters.weightWithUnit = (value) ->
+    value / 1000 + ' ' + CartJS.settings.weightUnit;
+
   rivets.formatters.productImageSize = (src, size) ->
     CartJS.Utils.getSizedImageUrl(src, size)
 


### PR DESCRIPTION
Hi,

This PR adds a weight formatter. Unfortunately, I've checked Shopify documentation and it does not have any method similar to formatMoney in their utility lib, so we're forced to do it ourself.

I've added the "kg" unit by default for compatibility purpose (which is the default by Shopify). Please note that Shopify does not have a {{shop.weight_unit}} variable exposed, so people that want to change that will be forced to modify manually the unit.