### PR TITLE
Fix no image

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -96,4 +96,5 @@ CartJS.Utils =
   #
   # If it's not available, just return the original URL.
   getSizedImageUrl: (src, size) ->
+    if src === null then 'https://cdn.shopify.com/s/images/admin/no-image-' + size + '.gif'
     if window.Shopify?.Image?.getSizedImageUrl? then Shopify.Image.getSizedImageUrl(src, size) else src


### PR DESCRIPTION
This is a fix for #43 .

We cannot use the default Shopify helper because after some trying, it appears that the no-image specific URL are not append "_large", "_grande"... but "-grande", "-large"... so the large version of the "no-image" placeholder is https://cdn.shopify.com/s/images/admin/no-image-large.gif and not https://cdn.shopify.com/s/images/admin/no-image_large.gif

Let me know, as I'm not a CoffeeScript expert, I'm not even sure how to properly return...