### PR TITLE
Added `cart.ready` event to `CartJS.init`.

### DIFF
--- a/docs/reference/sections/events/ready.md
+++ b/docs/reference/sections/events/ready.md
@@ -1,0 +1,7 @@
+Triggered after Cart.js has completed initialising.
+
+```js
+$(document).on('cart.ready', function(event, cart) {
+    // Event handling here.
+});
+```

--- a/src/cartjs.coffee
+++ b/src/cartjs.coffee
@@ -51,6 +51,7 @@ CartJS.init = (cart, settings = {}) ->
   # Initialise DOM Binding through Rivets module.
   # Performs a no-op if Rivets.js isn't present.
   CartJS.Rivets.init()
+  $(document).trigger('cart.ready', [CartJS.cart]);
 
 # Configure CartJS with the given settings object.
 CartJS.configure = (settings = {}) ->


### PR DESCRIPTION
This commit includes a `cart.ready` event to simplify subsequent events to be triggered after Cart.js has finished initialising.