### PR TITLE
Added Rivets Formatter for inversion of `eq` called `unless`.

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -61,6 +61,9 @@ if 'rivets' of window
   rivets.formatters.eq = (a, b) ->
     a == b
 
+  rivets.formatters.unless = (a, b) ->
+    a != b
+
   rivets.formatters.lt = (a, b) ->
     a < b
 


### PR DESCRIPTION
This is a possible fix for discolabs/cartjs#48, allowing for the following example usage:

> To show all line items except for those where the product title equals `Title 1`

```html
<div class="line-item" rv-show="item.title | unless 'Title 1'">
  <!-- Line Item Properties -->
</div>
```

(Also, haven't updated docs in this case as pending further expansion of DOM Binding Guide)