### PR TITLE
Added two new String Rivets Formatters: `includes` and `match`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 ### Added
-- **PR #50** Added two new Rivets formatters: `includes` and `match`  
+- Two new Rivets formatters: `includes` and `match`  
 
 ## 0.3.8 - 2015-10-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-No unreleased changes.
+- **PR #50** Added two new Rivets formatters: `includes` and `match`  
 
 ## 0.3.8 - 2015-10-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Added
 - **PR #50** Added two new Rivets formatters: `includes` and `match`  
 
 ## 0.3.8 - 2015-10-27

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -61,6 +61,12 @@ if 'rivets' of window
   rivets.formatters.eq = (a, b) ->
     a == b
 
+  rivets.formatters.includes = (a, b) ->
+    a.indexOf(b) >= 0
+
+  rivets.formatters.match = (a, regexp, flags) ->
+    a.match(new RegExp(regexp, flags))
+
   rivets.formatters.lt = (a, b) ->
     a < b
 


### PR DESCRIPTION
* `includes` accepts a case-sensitive string needle, and will return true if that needle is found in the haystack
* `match` accepts a regexp (as a string to pass through as a Rivets argument, therefore not wrapped in `/`), and an optional argument for any flags (i.e. `'i'`)

> `match` example:
`rv-if="item.title | match 'shoe|shirt' 'i'"`