### PR TITLE
Added new Rivets Formatter: `property`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Removed
 - IE8 Compatibility mode
+- New Rivets formatter: `property` - returns passed in line item property
 
 ## 0.3.9 - 2015-11-11
 ### Added

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -59,6 +59,9 @@ if 'rivets' of window
   rivets.formatters.match = (a, regexp, flags) ->
     a.match(new RegExp(regexp, flags))
 
+  rivets.formatters.property = (properties, property) ->
+    properties[property];
+
   rivets.formatters.lt = (a, b) ->
     a < b
 


### PR DESCRIPTION
The use case for this is maybe a little niche, but thought it might be useful to include. You can of course use `{ item.properties.property }` to access a given line item's property, but this is only useful if you are able to explicitly specify the property key within the Rivets tag. 

An example use case would be where the key is stored in a liquid variable:
```html
<span>{ item.properties | property '{{ prop }}' }</span>
```

Interested to know your thoughts on whether this should be included.