### PR TITLE
Added products_in_cart, all_products_in_cart formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Added
+- products_in_cart, all_products_in_cart formatters returning boolean results
 ### Removed
 - IE8 Compatibility mode
 

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -83,6 +83,24 @@ if 'rivets' of window
   rivets.formatters.append = (a, b) ->
     a + b
 
+  # Returns true if any of the provided product handles (as comma-separated string) are found in `items`
+  rivets.formatters.products_in_cart = (items, query) ->
+    query.replace(' ', '').split(',')
+    result = $.map(items, (item) ->
+      if query.indexOf(item.handle) > -1
+        return item
+    )
+    result.length > 0
+
+  # Returns true if all of the provided product handles (as comma-separated string) are found in `items`
+  rivets.formatters.all_products_in_cart = (items, query) ->
+    query = query.replace(' ', '').split(',')
+    result = $.map(items, (item) ->
+      if query.indexOf(item.handle) > -1
+        return item
+    )
+    result.length == query.length
+
   # Add Shopify-specific formatters for Rivets.js.
   rivets.formatters.money = (value, currency) ->
     CartJS.Utils.formatMoney(value, CartJS.settings.moneyFormat, 'money_format', currency)


### PR DESCRIPTION
Submit this PR for @gavinballard to decide if worth including in core library - I needed to be able to drive UI element presence based on whether or not the cart contained certain products, and wanted a rivets-based approach rather than binding DOM manipulation to the `cart.requestComplete` event.

Usage example:

``` html
<ul class="items">
  <!-- Cart Contents -->
</ul>

<div class="product-specific-message" rv-if="cart.items | products_in_cart 'handle-1, handle-2'">
  <!-- Element present if either handle-1 or handle-2 products are in cart -->
</div>
```

I can of course easily include this privately in my project, but wanted to get your thoughts on a broader appeal for the library.
