### PR TITLE
Formatters - added array_element, for accessing an element at a given index within an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Added
+- New Rivets formatter: `array_element` for accessing a specific element within a provided array
 ### Removed
 - IE8 Compatibility mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 ### Added
-- New Rivets formatter: `array_element` for accessing a specific element within a provided array
+- New Rivets formatter: `array_element`, `array_first`, `array_last`
 ### Removed
 - IE8 Compatibility mode
 

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -86,6 +86,12 @@ if 'rivets' of window
   rivets.formatters.array_element = (array, index) ->
     array[index];
 
+  rivets.formatters.array_first = (array) ->
+    array[0];
+
+  rivets.formatters.array_last = (array) ->
+    array[array.length - 1];
+
   # Add Shopify-specific formatters for Rivets.js.
   rivets.formatters.money = (value, currency) ->
     CartJS.Utils.formatMoney(value, CartJS.settings.moneyFormat, 'money_format', currency)

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -83,6 +83,9 @@ if 'rivets' of window
   rivets.formatters.append = (a, b) ->
     a + b
 
+  rivets.formatters.array_element = (array, index) ->
+    array[index];
+
   # Add Shopify-specific formatters for Rivets.js.
   rivets.formatters.money = (value, currency) ->
     CartJS.Utils.formatMoney(value, CartJS.settings.moneyFormat, 'money_format', currency)


### PR DESCRIPTION
### Use Case
As part of a line item, you need to be able to render one or more of the variant options, separate from the `line_item.title` property.

###### Example (where `variant_options` is an array of that line item's variant option values):
```html
<div class="title" rv-text="item.product_title"></div>
<div class="size" rv-text="item.variant_options | arrayElement 0"></div>
```

I wasn't aware of another way of accessing the elements of this array with Rivets, but let me know if there is an existing way of solving this that renders this additional formatter unnecessary.
