### PR TITLE
Events - added cart.itemsAdded and cart.itemsRemoved events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 No unreleased changes.
+### Added
+- New events - `cart.itemsAdded` and `cart.itemsRemoved`, triggered when either event is successful
 
 ## 0.4.0 - 2016-02-11
 ### Added

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -198,6 +198,12 @@
         },
         "request-complete": {
           "title": "cart.requestComplete"
+        },
+        "items-added": {
+          "title": "cart.itemsAdded"
+        },
+        "items-removed": {
+          "title": "cart.itemsRemoved"
         }
       }
     },

--- a/docs/reference/sections/events/items-added.md
+++ b/docs/reference/sections/events/items-added.md
@@ -1,0 +1,7 @@
+Triggered after Cart.js has successfully added an item to the cart.
+
+```js
+$(document).on('cart.itemsAdded', function(event, cart) {
+    // Event handling here.
+});
+```

--- a/docs/reference/sections/events/items-removed.md
+++ b/docs/reference/sections/events/items-removed.md
@@ -1,0 +1,7 @@
+Triggered after Cart.js has successfully removed an item to the cart.
+
+```js
+$(document).on('cart.itemsRemoved', function(event, cart) {
+    // Event handling here.
+});
+```

--- a/src/core.coffee
+++ b/src/core.coffee
@@ -15,6 +15,10 @@ CartJS.Core =
     data = CartJS.Utils.wrapKeys(properties)
     data.id = id
     data.quantity = quantity
+    if !options.success
+      options = $.extend(options, {success: ->
+        $(document).trigger('cart.itemsAdded', [CartJS.cart])
+      })
     CartJS.Queue.add '/cart/add.js', data, options
     CartJS.Core.getCart()
 
@@ -29,6 +33,10 @@ CartJS.Core =
 
   # Remove an existing line item.
   removeItem: (line, options = {}) ->
+    if !options.success
+      options = $.extend(options, {success: ->
+        $(document).trigger('cart.itemsRemoved', [CartJS.cart])
+      })
     CartJS.Core.updateItem line, 0, {}, options
 
   # Update item by ID


### PR DESCRIPTION
Use case that lead to this was needing to build in Google Analytics event tracking on these specific actions. May also be of interest to conversation in #5 (event names have been set to reflect conversation there, though this may benefit from more data being passed to the event).

@gavinballard Would be interested to know if you think this approach would support passing in to the event details about the product that was added/removed...
