### PR TITLE
Avoid using cached request

### DIFF
--- a/src/core.coffee
+++ b/src/core.coffee
@@ -8,7 +8,7 @@ CartJS.Core =
   getCart: (options = {}) ->
     options.type = 'GET'
     options.updateCart = true
-    CartJS.Queue.add '/cart.js', {}, options
+    CartJS.Queue.add '/cart.js?v=' + new Date().getTime(), {}, options
 
   # Add a new line item to the cart.
   addItem: (id, quantity = 1, properties = {}, options = {}) ->


### PR DESCRIPTION
Fixes #158 
- There's a common issue when hitting the cart.js endpoint from Shopify,
it's cached by default so it's causing an issue when loading items from
the cart, sometimes the cart shows up as empty when hitting the back
button.

This commit adds a timestamp to the API call to get a non-cached
response. This approach is done by Shopify itself to avoid loading cached assets
![image](https://user-images.githubusercontent.com/2782816/89930495-74f33d80-dbd0-11ea-923f-1a76f02213dd.png)


**Note:** I am maintaining a Shopify theme and we have a custom slide cart component created from scratch (no libraries used), we faced the same issue and before creating a fix for this I found this library and I would like to contribute to it with that simple fix.
