### PR TITLE
Better check for existence of `rivets` variable

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -2,7 +2,7 @@
 # Adds Rivets.js functionality to CartJS if Rivets.js is available.
 # -----------------------------------------------------------------
 
-if rivets
+if rivets?
 
   # Rivets.js has been loaded, so declare the CartJS.Rivets module.
   CartJS.Rivets =


### PR DESCRIPTION
Fixes #189 

An attempt to read a `rivets` variable that has never been defined in the cartjs-only build causes an error, not allowing anything else to work.

```
Uncaught ReferenceError: rivets is not defined
```